### PR TITLE
Remove noncanonical definitions.

### DIFF
--- a/src/Data/Optional.hs
+++ b/src/Data/Optional.hs
@@ -112,7 +112,6 @@ instance Applicative Optional where
     _          <*> _          = Default
 
 instance Monad Optional where
-    return = Specific
 
     Default    >>= _ = Default
     Specific x >>= f = f x


### PR DESCRIPTION
This appeases the `-Wnoncanonical-monad-instances` warning. A future GHC release will treat noncanonical definitions as errors. See https://github.com/haskell/core-libraries-committee/issues/328.